### PR TITLE
Offline storage design and implementation 

### DIFF
--- a/MapCore/pom.xml
+++ b/MapCore/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>org.wwarn.mapssurveyor</groupId>
         <artifactId>maps-surveyor-parent</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wwarn.mapssurveyor</groupId>
     <artifactId>MapCore</artifactId>
     <packaging>jar</packaging>
     <name>MapCore</name>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <inceptionYear>2013</inceptionYear>
 

--- a/SurveyorCore/pom.xml
+++ b/SurveyorCore/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>org.wwarn.mapssurveyor</groupId>
         <artifactId>maps-surveyor-parent</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <!-- POM file generated with GWT webAppCreator -->
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wwarn.mapssurveyor</groupId>
     <artifactId>SurveyorCore</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-    <version>1.1.3-SNAPSHOT</version>
     <name>SurveyorCore</name>
 
     <inceptionYear>2013</inceptionYear>
@@ -285,6 +285,20 @@
             <groupId>net.sf.jsr107cache</groupId>
             <artifactId>jsr107cache</artifactId>
             <version>1.1</version>
+        </dependency>
+
+        <!-- local forage gwt wrapper-->
+        <dependency>
+            <groupId>us.storee.gwt</groupId>
+            <artifactId>gwt-localForage</artifactId>
+            <version>1.2.3-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Used for serialisation only of java classes to string-->
+        <dependency>
+            <groupId>com.seanchenxi.gwt</groupId>
+            <artifactId>gwt-storage</artifactId>
+            <version>1.3.0</version>
         </dependency>
 
     </dependencies>

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/BitSet.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/BitSet.java
@@ -47,12 +47,23 @@ import java.util.Set;
 
 /**
  * Wrapper for the following https://github.com/atonparker/bitterset impl
+ * TODO make this an external package and add to github
  */
 public class BitSet  {
     static{
-        String text = Resources.IMPL.bitSetScript().getText();
-        ScriptInjector.fromString(text).setWindow(ScriptInjector.TOP_WINDOW).inject();
+        if (!isLoaded()) {
+            String text = Resources.IMPL.bitSetScript().getText();
+            ScriptInjector.fromString(text).setWindow(ScriptInjector.TOP_WINDOW).inject();
+        }
     }
+
+
+    public static native boolean isLoaded()/*-{
+        if (typeof $wnd.some_externally_sourced_code === "undefined" || typeof $wnd.some_externally_sourced_code.BitSet === "undefined"  || $wnd.some_externally_sourced_code.BitSet === null) {
+            return false;
+        }
+        return true;
+    }-*/;
 
     private JavaScriptObject bitset;
 

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/DataSchema.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/DataSchema.java
@@ -50,11 +50,13 @@ import java.util.Set;
  * Time: 11:42
  */
 public class DataSchema implements IsSerializable, Serializable{
+    private String uniqueId = "defaultDataSchemaUniqueID";
     // insertion order is preserved
     LinkedHashMap<String, DataSchemaRecord> fieldNameAndAssociatedType = new LinkedHashMap<String, DataSchemaRecord>();
     private int ordinal = 0;
 
     public DataSchema(DatasourceConfig datasourceConfig){
+        this.uniqueId = datasourceConfig.getUniqueId();
         Map<String,DatasourceConfig.SchemaConfig.FieldConfig> fields = datasourceConfig.getConfig().getFields();
         for (String key : fields.keySet()) {
             DatasourceConfig.SchemaConfig.FieldConfig fieldConfig = fields.get(key);
@@ -104,6 +106,10 @@ public class DataSchema implements IsSerializable, Serializable{
         return fieldNameAndAssociatedType.keySet();
     }
 
+    public String getUniqueId() {
+        return uniqueId;
+    }
+
     static class DataSchemaRecord implements IsSerializable, Serializable {
         private DataType dataType;
         private int ordinal;
@@ -124,5 +130,62 @@ public class DataSchema implements IsSerializable, Serializable{
         public int getOrdinal() {
             return ordinal;
         }
+
+        @Override
+        public String toString() {
+            return "DataSchemaRecord{" +
+                    "dataType=" + dataType +
+                    ", ordinal=" + ordinal +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DataSchemaRecord that = (DataSchemaRecord) o;
+
+            if (ordinal != that.ordinal) return false;
+            return dataType == that.dataType;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = dataType.hashCode();
+            result = 31 * result + ordinal;
+            return result;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "DataSchema{" +
+                "uniqueId='" + uniqueId + '\'' +
+                ", fieldNameAndAssociatedType=" + fieldNameAndAssociatedType +
+                ", ordinal=" + ordinal +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DataSchema that = (DataSchema) o;
+
+        if (ordinal != that.ordinal) return false;
+        if (!uniqueId.equals(that.uniqueId)) return false;
+        return fieldNameAndAssociatedType.equals(that.fieldNameAndAssociatedType);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = uniqueId.hashCode();
+        result = 31 * result + fieldNameAndAssociatedType.hashCode();
+        result = 31 * result + ordinal;
+        return result;
     }
 }

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/DataTableConversionUtility.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/DataTableConversionUtility.java
@@ -34,7 +34,6 @@ package org.wwarn.surveyor.client.core;
  */
 
 import com.allen_sauer.gwt.log.client.Log;
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.visualization.client.AbstractDataTable;
 
@@ -77,6 +76,7 @@ public class DataTableConversionUtility {
             }
             recordListBuilder.addRecord((fields));
         }
-        return recordListBuilder.createRecordList();
+        String dataSourceHash = "";
+        return recordListBuilder.createRecordList(dataSourceHash);
     }
 }

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/FacetList.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/FacetList.java
@@ -89,6 +89,25 @@ public class FacetList implements Iterable<FacetList.FacetField>, IsSerializable
                     ", distinctFacetValues=" + distinctFacetValues +
                     '}';
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            FacetField that = (FacetField) o;
+
+            if (!facetField.equals(that.facetField)) return false;
+            return distinctFacetValues.equals(that.distinctFacetValues);
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = facetField.hashCode();
+            result = 31 * result + distinctFacetValues.hashCode();
+            return result;
+        }
     }
 
     @Override
@@ -96,5 +115,21 @@ public class FacetList implements Iterable<FacetList.FacetField>, IsSerializable
         return "FacetList{" +
                 "facetFields=" + facetFields +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FacetList facetList = (FacetList) o;
+
+        return !(facetFields != null ? !facetFields.equals(facetList.facetFields) : facetList.facetFields != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return facetFields != null ? facetFields.hashCode() : 0;
     }
 }

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/OfflineStorageKeyProvider.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/OfflineStorageKeyProvider.java
@@ -1,0 +1,61 @@
+package org.wwarn.surveyor.client.core;
+
+import com.google.gwt.user.client.rpc.IsSerializable;
+
+import java.io.Serializable;
+
+/**
+ * Created by nigelthomas on 03/07/2015.
+ */
+class OfflineStorageKeyProvider implements IsSerializable, Serializable {
+    private String currentKey;
+    private String oldKey;
+
+    private OfflineStorageKeyProvider() {
+    }
+
+    public OfflineStorageKeyProvider(String currentKey, String oldKey) {
+        this.currentKey = currentKey;
+        this.oldKey = oldKey;
+    }
+
+    public OfflineStorageKeyProvider(String dataSourceHash) {
+        this.currentKey = dataSourceHash;
+        this.oldKey = null;
+    }
+
+    public String getCurrentKey() {
+        return currentKey;
+    }
+
+    public String getOldKey() {
+        return oldKey;
+    }
+
+    @Override
+    public String toString() {
+        return "OfflineStorageKeyProvider{" +
+                "currentKey='" + currentKey + '\'' +
+                ", oldKey='" + oldKey + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OfflineStorageKeyProvider that = (OfflineStorageKeyProvider) o;
+
+        if (!currentKey.equals(that.currentKey)) return false;
+        return !(oldKey != null ? !oldKey.equals(that.oldKey) : that.oldKey != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = currentKey.hashCode();
+        result = 31 * result + (oldKey != null ? oldKey.hashCode() : 0);
+        return result;
+    }
+}

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordList.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordList.java
@@ -119,6 +119,27 @@ public class RecordList implements IsSerializable, Serializable{
                 '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RecordList that = (RecordList) o;
+
+        if (!schema.equals(that.schema)) return false;
+        if (!records.equals(that.records)) return false;
+        return dataSourceHash.equals(that.dataSourceHash);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = schema.hashCode();
+        result = 31 * result + records.hashCode();
+        result = 31 * result + dataSourceHash.hashCode();
+        return result;
+    }
+
     public static class Record implements IsSerializable, Serializable{
         //array of fields
         // map of column names to fields

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordList.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordList.java
@@ -34,7 +34,6 @@ package org.wwarn.surveyor.client.core;
  */
 
 import com.allen_sauer.gwt.log.client.Log;
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.IsSerializable;
 
 import java.io.Serializable;
@@ -50,12 +49,25 @@ import java.util.*;
 public class RecordList implements IsSerializable, Serializable{
     protected DataSchema schema;
     protected List<Record> records = new ArrayList<Record>();
+    protected String dataSourceHash = "";
 
     public RecordList(DataSchema schema) {
         this.schema = schema;
     }
 
     public RecordList() {
+    }
+
+    /**
+     * Return a hash of the underlying dataset, useful to check if underlying data has changed
+     * @return
+     */
+    public String getDataSourceHash() {
+        return dataSourceHash;
+    }
+
+    public void setDataSourceHash(String dataSourceHash) {
+        this.dataSourceHash = dataSourceHash;
     }
 
     public List<Record> getRecords() {
@@ -78,7 +90,7 @@ public class RecordList implements IsSerializable, Serializable{
             }
             uniqueKeys.add(uniqueKeyField);
         }
-        return uniqueRecordListBuilder.createRecordList();
+        return uniqueRecordListBuilder.createRecordList(dataSourceHash);
     }
 
     public void add(Record record) {
@@ -103,6 +115,7 @@ public class RecordList implements IsSerializable, Serializable{
     public String toString() {
         return "RecordList{" +
                 "records=" + records +
+                ", dataSourceHash=" + dataSourceHash +
                 '}';
     }
 

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordListBuilder.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordListBuilder.java
@@ -35,6 +35,7 @@ package org.wwarn.surveyor.client.core;
 
 import com.allen_sauer.gwt.log.client.Log;
 import com.google.gwt.core.client.GWT;
+import org.wwarn.mapcore.client.utils.StringUtils;
 
 import java.util.List;
 
@@ -84,7 +85,7 @@ public class RecordListBuilder {
         return this;
     }
 
-    public RecordList createRecordList() {
+    public RecordList createRecordList(String dataSourceHash) {
         switch (compressionMode) {
             case NONE:
                 Log.error("Using RecordList uncompressed");
@@ -95,6 +96,8 @@ public class RecordListBuilder {
                 ((RecordListCompressedImpl) this.recordList).initialise();
                 break;
         }
+        dataSourceHash = StringUtils.ifEmpty(dataSourceHash, "");
+        recordList.setDataSourceHash(dataSourceHash);
         return recordList;
     }
 }

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordListCompressedImpl.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordListCompressedImpl.java
@@ -34,10 +34,7 @@ package org.wwarn.surveyor.client.core;
  */
 
 import com.allen_sauer.gwt.log.client.Log;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.IsSerializable;
 
-import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -77,7 +74,7 @@ public class RecordListCompressedImpl extends RecordList {
             }
             uniqueKeys.add(uniqueKeyField);
         }
-        return uniqueRecordListBuilder.createRecordList();
+        return uniqueRecordListBuilder.createRecordList(dataSourceHash);
     }
 
     @Override

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordListCompressedWithInvertedIndexImpl.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/RecordListCompressedWithInvertedIndexImpl.java
@@ -33,6 +33,8 @@ package org.wwarn.surveyor.client.core;
  * #L%
  */
 
+import com.allen_sauer.gwt.log.client.Log;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -58,6 +60,7 @@ public class RecordListCompressedWithInvertedIndexImpl extends RecordListCompres
     @Override
     public void addRecord(String... fields) {
         super.addRecord(fields);
+        Log.debug(Arrays.toString(fields));
         index.addDocument(fields);
     }
 

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/XMLApplicationLoader.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/XMLApplicationLoader.java
@@ -34,6 +34,7 @@ package org.wwarn.surveyor.client.core;
  */
 
 import com.google.gwt.maps.client.MapTypeId;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.xml.client.*;
 import org.wwarn.mapcore.client.common.types.FilterConfigVisualization;
 import org.wwarn.mapcore.client.components.customwidgets.facet.FacetType;
@@ -118,6 +119,7 @@ public class XMLApplicationLoader implements ApplicationContext {
             DatasourceConfig datasourceConfig = null;
 
             final String type = getAttributeByName(item, "type");
+            final String uniqueId = getAttributeByName(item, "id");
             String dataSourceType = StringUtils.ifEmpty(DataSourceProvider.valueOf(type).name(), DataSourceProvider.LocalClientSideDataProvider.name());
             for (int i = 0; i < childNodes.getLength(); i++) {
                 Node currentNode = childNodes.item(i);
@@ -133,7 +135,9 @@ public class XMLApplicationLoader implements ApplicationContext {
                     if(fileLocation == null){
                         throw new XMLUtils.ParseException("fileLocation is null");
                     }
-                    datasourceConfig = new DatasourceConfig(fileLocation, dataSourceType);
+                    String generatedName = "fl"+SafeHtmlUtils.htmlEscape(fileLocation.replaceAll("/", ""));
+                    String parsedUniqueId = StringUtils.ifEmpty(uniqueId, generatedName);
+                    datasourceConfig = new DatasourceConfig(parsedUniqueId, fileLocation, dataSourceType);
                 }
 
                 if(currentNode.getNodeName().equals("schema")){

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/model/DatasourceConfig.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/model/DatasourceConfig.java
@@ -44,9 +44,14 @@ public class DatasourceConfig implements Config {
     private final DataSourceProvider dataSourceProvider;
     private final String filename;
     private final SchemaConfig config = new SchemaConfig();
+    private final String uniqueId;
 
     public DataSourceProvider getDataSourceProvider() {
         return dataSourceProvider;
+    }
+
+    public String getUniqueId() {
+        return uniqueId;
     }
 
     public static class SchemaConfig {
@@ -79,7 +84,8 @@ public class DatasourceConfig implements Config {
         }
     }
 
-    public DatasourceConfig(String filename, String dataSourceType) {
+    public DatasourceConfig(String uniqueId, String filename, String dataSourceType) {
+        this.uniqueId = uniqueId;
         this.filename = filename;
         this.dataSourceProvider = DataSourceProvider.valueOf(dataSourceType);
     }

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/util/OfflineStorageUtil.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/util/OfflineStorageUtil.java
@@ -1,0 +1,105 @@
+package org.wwarn.surveyor.client.util;
+
+/*
+ * #%L
+ * SurveyorCore
+ * %%
+ * Copyright (C) 2013 - 2015 University of Oxford
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the University of Oxford nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import org.jetbrains.annotations.NotNull;
+import org.wwarn.mapcore.client.utils.StringUtils;
+import org.wwarn.surveyor.client.core.QueryResult;
+import us.storee.gwt.libs.localforage.client.LocalForage;
+import us.storee.gwt.libs.localforage.client.LocalForageCallback;
+
+import java.util.Objects;
+
+/**
+ * Created by nigelthomas on 02/07/2015.
+ */
+public class OfflineStorageUtil<T> {
+    private final String uniqueKey;
+    private final Class<T> clazz;
+    private LocalForage offlineDataStore = new LocalForage();
+    private SerializationUtil serializationUtil = new SerializationUtil();
+
+    public OfflineStorageUtil(Class<T> clazz,String uniqueKey) {
+        if(StringUtils.isEmpty(uniqueKey)){
+            throw new IllegalArgumentException("key must be set");
+        }
+        Objects.requireNonNull(clazz);
+        this.clazz = clazz;
+        this.uniqueKey = uniqueKey;
+    }
+
+
+    public void fetch(final AsyncCommand asyncCommand) {
+        // using schema uniqueID to fetch queryResult
+        offlineDataStore.getItem(uniqueKey, new LocalForageCallback<String>() {
+            @Override
+            public void onComplete(boolean error, String storedString) {
+                if (!error && storedString != null) {
+                    final T queryResult = serializationUtil.deserialize(clazz, storedString);
+                    if(queryResult != null) {
+                        asyncCommand.success(queryResult); return;
+                    }
+                }
+                asyncCommand.failure();
+            }
+        });
+    }
+
+    public void store(@NotNull final T object, final AsyncCommand asyncCommand) {
+        // using schema uniqueID to fetch queryResult
+        Objects.requireNonNull(object);
+        final String queryResultSerialisedString = serializationUtil.serialize(clazz, object);
+        offlineDataStore.setItem(uniqueKey, queryResultSerialisedString, new LocalForageCallback<String>() {
+            @Override
+            public void onComplete(boolean error, String storedString) {
+                if (!error && storedString != null) {
+                    asyncCommand.success(object);
+                } else asyncCommand.failure();
+            }
+        });
+    }
+
+    public interface AsyncCommand<T> {
+        /**
+         * Success only if result was found
+         * @param objectToStore
+         */
+        void success(@NotNull T objectToStore);
+
+        /**
+         * Failure if object not found or was null
+         */
+        void failure();
+    }
+}

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/util/SerializationUtil.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/util/SerializationUtil.java
@@ -1,10 +1,10 @@
-package org.wwarn.surveyor.client.core;
+package org.wwarn.surveyor.client.util;
 
 /*
  * #%L
  * SurveyorCore
  * %%
- * Copyright (C) 2013 - 2014 University of Oxford
+ * Copyright (C) 2013 - 2015 University of Oxford
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -33,59 +33,42 @@ package org.wwarn.surveyor.client.core;
  * #L%
  */
 
-import com.google.gwt.user.client.rpc.IsSerializable;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.SerializationException;
+import com.seanchenxi.gwt.storage.client.serializer.StorageSerializer;
 
 /**
- * Simple pojo that holds a RecordList and FacetList
- * Created with IntelliJ IDEA.
- * User: nigel
- * Date: 19/07/13
- * Time: 11:24
+ * Supports serialisation of GWT Java objects to string and vice versa
+ * Uses gwt-storage codebase to facilitate this, reuses GWT RPC mechanism
  */
-public class QueryResult implements IsSerializable{
-    private RecordList recordList;
-    private FacetList facetFields;
+public class SerializationUtil {
 
-    public QueryResult(RecordList recordList, FacetList facetFields) {
-        this.recordList = recordList;
-        this.facetFields = facetFields;
+    private static final StorageSerializer storageSerializer = GWT.create(StorageSerializer.class);
+
+    public <T> String serialize(Class<T> aClass, T object1){
+        String seralisedOutput = "";
+        try {
+            seralisedOutput = storageSerializer.serialize(aClass, object1);
+        } catch (SerializationException e) {
+            throw new IllegalStateException("unable to serialise", e);
+        }
+        return seralisedOutput;
     }
 
-    public QueryResult() {
-    }
-
-    public FacetList getFacetFields() {
-        return facetFields;
-    }
-
-    public RecordList getRecordList() {
-        return recordList;
-    }
-
-    @Override
-    public String toString() {
-        return "QueryResult{" +
-                "recordList=" + recordList +
-                ", facetFields=" + facetFields +
-                '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        QueryResult that = (QueryResult) o;
-
-        if (recordList != null ? !recordList.equals(that.recordList) : that.recordList != null) return false;
-        return !(facetFields != null ? !facetFields.equals(that.facetFields) : that.facetFields != null);
-
-    }
-
-    @Override
-    public int hashCode() {
-        int result = recordList != null ? recordList.hashCode() : 0;
-        result = 31 * result + (facetFields != null ? facetFields.hashCode() : 0);
-        return result;
+    /**
+     * Returns an object from a serialised string
+     * @param clazz Class.name value
+     * @param stringContainingSerialisedInput
+     * @param <T>
+     * @return
+     */
+    public <T> T deserialize(Class<T> clazz, String stringContainingSerialisedInput) {
+        T instance;
+        try {
+            instance = storageSerializer.deserialize(clazz, stringContainingSerialisedInput);
+        } catch (SerializationException e) {
+            throw new IllegalStateException("unable to serialise", e);
+        }
+        return instance;
     }
 }

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/server/core/FileVersionUtil.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/server/core/FileVersionUtil.java
@@ -1,0 +1,91 @@
+package org.wwarn.surveyor.server.core;
+
+/*
+ * #%L
+ * SurveyorCore
+ * %%
+ * Copyright (C) 2013 - 2015 University of Oxford
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the University of Oxford nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
+import java.io.*;
+import java.nio.file.Files;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+/**
+ * Takes a file and returns a version no of the file
+ * Calculate version of a file, based on stored last modified
+ */
+public class FileVersionUtil {
+    public FileVersionUtil() {
+    }
+
+
+    /**
+     * Gets md5 hashcode from file
+     * @param file
+     * @return
+     */
+    public String calculateVersionFrom(@NotNull File file){
+        Objects.requireNonNull(file, "file argument cannot be null");
+        //todo could optimise by store hash against file modified time, on subsequent calls, check file modified time first to determine file and time is present and return previous data.
+        MessageDigest md = getDigest();
+        try(DigestInputStream digestInputStream = new DigestInputStream(Files.newInputStream(file.toPath()), md)){
+            while(digestInputStream.read() != -1);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        final byte[] digest = md.digest();
+        final String digestHex = convertBinaryDigestToHexStringDigest(digest);
+        return digestHex;
+    }
+
+    @NotNull
+    private String convertBinaryDigestToHexStringDigest(byte[] digest) {
+        return (new HexBinaryAdapter()).marshal(digest);
+    }
+
+    static MessageDigest messageDigest;
+    public MessageDigest getDigest() {
+        try {
+
+            if (messageDigest == null) {
+                messageDigest = MessageDigest.getInstance("MD5");
+            }
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return messageDigest;
+    }
+}

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/server/core/LuceneSearchServiceImpl.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/server/core/LuceneSearchServiceImpl.java
@@ -450,6 +450,7 @@ public class LuceneSearchServiceImpl implements SearchServiceLayer {
         for (ScoreDoc doc : docs) {
             final Document document = indexSearcher.doc(doc.doc);
             String[] fieldValues = new String[dataSchema.size()];
+            Arrays.fill(fieldValues, ""); //ensure all fields initialized to empty string
             for (IndexableField indexableField : document) {
                 final String fieldName = indexableField.name();
                 final int columnIndex = dataSchema.getColumnIndex(fieldName);

--- a/SurveyorCore/src/main/resources/org/wwarn/surveyor/SurveyorCore.gwt.xml
+++ b/SurveyorCore/src/main/resources/org/wwarn/surveyor/SurveyorCore.gwt.xml
@@ -51,10 +51,12 @@
     <inherits name="org.wwarn.mapcore.Map"/>
     <inherits name="com.google.gwt.visualization.Visualization"/>
     <inherits name='com.google.web.bindery.event.EventBinder'/>
+    <inherits name="us.storee.gwt.libs.localforage.LocalForage"/>
     <!--<inherits name='com.github.gwtd3.D3' />-->
 
     <!-- Logging -->
     <inherits name="com.allen_sauer.gwt.log.gwt-log-OFF" />
+    <inherits name="com.seanchenxi.gwt.storage.Storage"/>
 
     <!-- Specify the paths for translatable code                    -->
     <source path='client' />

--- a/SurveyorCore/src/main/resources/org/wwarn/surveyor/client/resources/config.xml
+++ b/SurveyorCore/src/main/resources/org/wwarn/surveyor/client/resources/config.xml
@@ -37,7 +37,7 @@
     <!--
    A sample data source, default might be the standard JSON data source
     -->
-    <datasource type="LocalClientSideDataProvider">
+    <datasource type="LocalClientSideDataProvider" id="surveyorCoreLocalClientSideDataProvider">
         <property name="fileLocation" value="data/publications.json"/>
         <schema>
             <field name="CLON" type="CoordinateLon"/> <!-- type would be controlled vocabulary containing: Coordinate, Date, String, Integer-->

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/DataProviderTestUtility.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/DataProviderTestUtility.java
@@ -51,7 +51,7 @@ public class DataProviderTestUtility {
 
     public DataSchema fetchSampleDataSchema() {
         String dataSourceType = DataSourceProvider.LocalClientSideDataProvider.name();
-        DatasourceConfig dataSourceConfig = new DatasourceConfig("f", dataSourceType);
+        DatasourceConfig dataSourceConfig = new DatasourceConfig("uniqueID","f", dataSourceType);
         DataSchema schema = new DataSchema(dataSourceConfig);
         schema.addField(FIELD_PUBLICATION_YEAR, DataType.DateYear);
         schema.addField("PUB", DataType.String);

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestRecordList.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestRecordList.java
@@ -79,7 +79,7 @@ public class GwtTestRecordList extends VisualizationTest {
 
     public void setupDefaultData(){
         String dataSourceType = DataSourceProvider.LocalClientSideDataProvider.name();
-        schema = new DataSchema(new DatasourceConfig("", dataSourceType));
+        schema = new DataSchema(new DatasourceConfig("UniqueId","", dataSourceType));
         schema.addField(UNIQUE_FIELD, DataType.Integer);
         schema.addField(NON_UNIQUE_FIELD, DataType.String);
         table = DataTable.create();

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestRecordList.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestRecordList.java
@@ -135,7 +135,8 @@ public class GwtTestRecordList extends VisualizationTest {
             System.out.println(compressionMode);
 
             RecordListBuilder recordListBuilder = new RecordListBuilder(compressionMode, dataProviderTestUtility.fetchSampleDataSchema());
-            RecordList recordList = recordListBuilder.createRecordList();
+            String dataSourceHash = "";
+            RecordList recordList = recordListBuilder.createRecordList(dataSourceHash);
             assertNotNull(recordList);
             switch (compressionMode) {
                 case NONE:
@@ -155,7 +156,7 @@ public class GwtTestRecordList extends VisualizationTest {
             for (int i = 0; i < 7; i++) {
                 recordListBuilder.addRecord("200"+i,"2b","3c","4d","5e","6f","7g", "180"+i);
             }
-            recordList = recordListBuilder.createRecordList();
+            recordList = recordListBuilder.createRecordList(dataSourceHash);
             assertNotNull(recordList);
             assertTrue(recordList instanceof RecordListCompressedWithInvertedIndexImpl);
             assertNotNull(recordList.toString());

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestXMLApplicationLoader.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestXMLApplicationLoader.java
@@ -127,6 +127,8 @@ public class GwtTestXMLApplicationLoader extends GWTTestCase {
         // check data schema
         DataSchema dataSchema = new DataSchema(datasource);
         assertNotNull(dataSchema);
+        assertNotNull(dataSchema.getUniqueId());
+        assertEquals("fldatapublications.json",dataSchema.getUniqueId());
         assertTrue(dataSchema.hasColumn("CLON"));
     }
 

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/mvp/view/plot/GwtTestGWTVizPlot.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/mvp/view/plot/GwtTestGWTVizPlot.java
@@ -120,7 +120,8 @@ public class GwtTestGWTVizPlot extends VisualizationTest {
             public void run() {
                 DataSchema dataschema = dataProviderTestUtility.fetchSampleDataSchema();
                 final RecordListBuilder recordListBuilder = new RecordListBuilder(RecordListBuilder.CompressionMode.CANONICAL, dataschema);
-                final RecordList data = recordListBuilder.createRecordList();
+                String dataSourceHash = "";
+                final RecordList data = recordListBuilder.createRecordList(dataSourceHash);
                 gwtVizPlot.qplot(new PlotOptions.Builder().setX("CLAT").setY("CLON").setData(data).setGeom(PlotOptions.Geometry.BAR).setXlab("x label").setYlab("y label").setMain("Main title").setSub("Sub Title").createPlotOptions());
             }
         });

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/server/core/FileVersionUtilTest.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/server/core/FileVersionUtilTest.java
@@ -1,0 +1,70 @@
+package org.wwarn.surveyor.server.core;
+
+/*
+ * #%L
+ * SurveyorCore
+ * %%
+ * Copyright (C) 2013 - 2015 University of Oxford
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the University of Oxford nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+/**
+ * Basic test classes for file version
+ */
+public class FileVersionUtilTest {
+    FileVersionUtil fileVersionUtil;
+
+    @Before
+    public void setUp() throws Exception {
+        fileVersionUtil = new FileVersionUtil();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullInput() throws Exception {
+        fileVersionUtil.calculateVersionFrom(null);
+    }
+
+    @Test
+    public void testEmptyFile() throws Exception {
+        final Path emptyFile = Files.createTempFile("emptyFile", ".txt");
+        final File file = emptyFile.toFile();
+        final String version = fileVersionUtil.calculateVersionFrom(file);
+        assertNotNull(version);
+        assertEquals("D41D8CD98F00B204E9800998ECF8427E",version);
+        file.deleteOnExit();
+    }
+}

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/server/core/LuceneSearchServiceImplTest.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/server/core/LuceneSearchServiceImplTest.java
@@ -45,7 +45,6 @@ import java.util.*;
 import static org.junit.Assert.*;
 
 /**
- * Created by suay on 8/1/14.
  */
 public class LuceneSearchServiceImplTest {
 
@@ -166,6 +165,7 @@ public class LuceneSearchServiceImplTest {
         filterQuery.addFilter("PY", "2010");
 
         List<RecordList.Record> records = luceneSearchService.queryTable(filterQuery, testUtility.getSelectorList(), 0, 10, null);
+        fail();
     }
 
     @Test

--- a/SurveyorSimpleDemoApp/pom.xml
+++ b/SurveyorSimpleDemoApp/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>org.wwarn.mapssurveyor</groupId>
         <artifactId>maps-surveyor-parent</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.example</groupId>
     <artifactId>SurveyorSimpleDemoApp</artifactId>
     <packaging>war</packaging>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>SurveyorSimpleDemoApp</name>
     <description>A demonstrator for the surveyor framework</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wwarn.mapssurveyor</groupId>
     <artifactId>maps-surveyor-parent</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <modules>
         <module>MapCore</module>
         <module>SurveyorCore</module>


### PR DESCRIPTION
Notes on changes made and design of offline data storage api for surveyor framework, in order to use this feature set datasource type to ClientSideSearchDataProvider

New attributes in data structure
SchemaUniqueID
Added a way to uniquely identify the underlying dataschema, this is based on a new id attribute, if supplied else, uses fileLocation of schema

DataSourceHash
Added version of underlying data, by taking a hash of the underlying json file and extended RecordList to store the hash.

Add an api endpoint to check if data has been updated, this should just return the DataSourceHash of the current schema.

Summary of offline logic
Offline first data storage and sync layer is implemented as follows:
On load, check if data is present in offline store, if not assume first load, else subsequent load logic follows.
On first load, fetch data from server and store in offline data store. The key for queryresult storage is based on the DataSourceHash and SchemaUniqueID. Also store a reference to the DataSourceHash, using the SchemaUniqueID as the key.
On subsequent loads, fetch data from offline store. First the SchemaUniqueID is used to fetch a reference to DataSourceHash. The data is then fetched based on DataSourceHash and SchemaUniqueID key.
Once load completes, check online servers for updated copy of the data. Use exponential back algorithm for polling the server to check fresh copies - avoids flooding the network. When an update exist, fetch data and use the new DataSourceHash against SchemaUniqueID to store the data, keep a reference to the old DataSourceHash. Send a data updated event, which can be used to notify the end user that data has been updated and to refresh browser.
On next load, if a reference exist to the old key, remove old data stored against old key.

Outputs:
LocalForage GWT wrapper updated for v 1.2.3 data api’s
Utility class added for offline storage, this is effectively a wrapper over local forage and extends it to allow Java value object persistence org.wwarn.surveyor.client.util.OfflineStorageUtil
Utility class added to calculate file version org.wwarn.surveyor.server.core.FileVersionUtil
Serialization utility added wrapping the gwt-storage serialisation code org.wwarn.surveyor.client.util.SerializationUtil
Added a ClientSideSearchDataProvider with most of the offline data storage logic org.wwarn.surveyor.client.core.ClientSideSearchDataProvider
Added a Bitset wrapper for GWT, should make this open source org.wwarn.surveyor.client.core.BitSet
Created an offline record list implementation containing an compressed inverted index, this in turn is converted to BitSet backed version in the ClientSideDataPriovider and used for querying org.wwarn.surveyor.client.core.RecordListCompressedWithInvertedIndexImpl

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/worldwideantimalarialresistancenetwork/wwarn-maps-surveyor/9)

<!-- Reviewable:end -->
