### PR TITLE
Date conversions from year only were incorrect, have addressed this i…

### DIFF
--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/ClientSideSearchDataProvider.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/ClientSideSearchDataProvider.java
@@ -646,7 +646,7 @@ public class ClientSideSearchDataProvider extends ServerSideSearchDataProvider i
         return ((FilterQuery.FilterFieldValue) filterQueryElement).getFieldsValue();
     }
 
-    static String leftPaddedInteger(int i) {
+    public static String leftPaddedInteger(int i) {
         if(i < 0){
             throw new IllegalArgumentException("Natural numbers only, does not support negative integers");
         }

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/DataType.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/core/DataType.java
@@ -69,9 +69,15 @@ public enum DataType implements IsSerializable {
 
         private static DefaultDateTimeFormatInfo info = new DefaultDateTimeFormatInfo();
 
+        public static Date parseDateInEnglishDayMonthYearFormat(String value) {
+            return getDateFormatFrom(DATE_FORMAT_DAY_MONTH_YEAR).parse(value);
+        }
+
         public static Date parseDateYearOnly(String value) {
             return getDateFormatFrom(DATE_FORMAT_YEAR_ONLY).parse(value);
         }
+
+
 
         /**
          * Attempt to parse dates, based on all supported formats
@@ -113,6 +119,7 @@ public enum DataType implements IsSerializable {
         }
 
         static Map<String, DateTimeFormat> cacheOfDateTimeFormat = new HashMap<>();
+
         public static DateTimeFormat getDateFormatFrom(final String pattern) {
 
             DateTimeFormat dateTimeFormat = cacheOfDateTimeFormat.get(pattern);

--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/mvp/view/filter/YearRangeSliderComposite.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/mvp/view/filter/YearRangeSliderComposite.java
@@ -203,13 +203,13 @@ public class YearRangeSliderComposite extends Composite{
                     }
                     if(StringUtils.isEmpty(filterByDateRangeSettings.getFieldFrom()) ||
                             StringUtils.isEmpty(filterByDateRangeSettings.getFieldTo())){
-                        filterChangedEvent.addFilter(parseDateYearOnly(currentMinYear), parseDateYearOnly(currentMaxYear));
+                        filterChangedEvent.addFilter(parseDateStartYearOnly(currentMinYear), parseDateEndYearOnly(currentMaxYear));
                     }else{
                         filterChangedEvent.addFilter(filterByDateRangeSettings.getFieldFrom(), filterByDateRangeSettings.getFieldTo(),
-                                parseDateYearOnly(currentMinYear), parseDateYearOnly(currentMaxYear));
+                                parseDateStartYearOnly(currentMinYear), parseDateEndYearOnly(currentMaxYear));
                     }
 
-                    filterChangedEvent.addFilter(parseDateYearOnly(currentMinYear), parseDateYearOnly(currentMaxYear));
+                    filterChangedEvent.addFilter(parseDateStartYearOnly(currentMinYear), parseDateEndYearOnly(currentMaxYear));
                 } else {
                     // if filter is set to default values then reset filter options
                     filterChangedEvent.resetField();
@@ -217,15 +217,16 @@ public class YearRangeSliderComposite extends Composite{
                 clientFactory.getEventBus().fireEvent(filterChangedEvent);
             }
 
-            private Date parseDateYearOnly(Integer yearOnly) {
-                return DataType.ParseUtil.parseDateYearOnly(yearOnly.toString());
+            private Date parseDateStartYearOnly(Integer yearOnly) {
+                return DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("01/01" + yearOnly.toString());
+            }
+            private Date parseDateEndYearOnly(Integer yearOnly) {
+                return DataType.ParseUtil.parseDateYearOnly("31/12/"+yearOnly.toString());
             }
         };
 
         dateSliderYuiWidgetImpl.addValueChangeHandler(valueChangeHandler);
         dateSliderYuiWidgetImpl.addShowRangeHandler(showRangeChangeHandler);
-
-
 
         return dateSliderYuiWidgetImpl;
     }

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/ClientSideSearchProviderTreeMapTest.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/ClientSideSearchProviderTreeMapTest.java
@@ -37,10 +37,7 @@ import com.google.gwt.i18n.shared.DateTimeFormat;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.*;
 
 import static org.junit.Assert.*;
 
@@ -68,11 +65,14 @@ public class ClientSideSearchProviderTreeMapTest {
         return ClientSideSearchDataProvider.leftPaddedInteger(i);
     }
 
+
+
     @Test
     public void testDateRange() throws Exception {
+
         final String[] dummyDateData = {
                 "1970-01-01T00:00:00.000+01:00",
-                "2001-11-08T00:00:00.000+00:00",
+                "2001-01-08T00:00:00.000+00:00",
                 "2002-02-17T00:00:00.000+00:00",
                 "2008-10-01T00:00:00.000+01:00",
                 "2009-01-01T00:00:00.000+00:00",
@@ -90,12 +90,37 @@ public class ClientSideSearchProviderTreeMapTest {
             dateMap.put(date, null);
         }
         final DateTimeFormat dateTimeFormat = DataType.ParseUtil.getDateFormatFrom(DataType.ISO_DATE_FORMAT);
-        final String startDate = dateTimeFormat.format(DataType.ParseUtil.parseDateYearOnly("2001"));
-        final String endDate = dateTimeFormat.format(DataType.ParseUtil.parseDateYearOnly("2002"));
+        final String startDate = dateTimeFormat.format(DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("01/01/2001"));
+        final String endDate = dateTimeFormat.format(DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("31/12/2003"));
         final NavigableMap navigableMap = dateMap.subMap(startDate, true, endDate, true);
         assertNotNull(navigableMap);
         assertTrue(navigableMap.size() > 0);
         assertEquals(2, navigableMap.size());
+    }
+
+    @Test
+    public void testDateYearOnlyRange() throws Exception {
+
+        final String[] dummyDateData = {
+                "00000002001",
+                "00000002002",
+                "00000002007",
+                "00000002008",
+                "00000002009",
+                "00000002010",
+                "00000002011",
+                "00000002012"};
+        assertEquals(8, dummyDateData.length);
+        for (String date : dummyDateData) {
+            dateMap.put(date, null);
+        }
+        final DateTimeFormat dateTimeFormat = DataType.ParseUtil.getDateFormatFrom(DataType.ISO_DATE_FORMAT);
+        final String startDate = ClientSideSearchDataProvider.leftPaddedInteger(2001);
+        final String endDate = ClientSideSearchDataProvider.leftPaddedInteger(2007);
+        final NavigableMap navigableMap = dateMap.subMap(startDate, true, endDate, true);
+        assertNotNull(navigableMap);
+        assertTrue(navigableMap.size() > 0);
+        assertEquals(3, navigableMap.size());
     }
 
     @Test

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/DataProviderTestUtility.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/DataProviderTestUtility.java
@@ -38,12 +38,17 @@ import com.google.gwt.json.client.JSONParser;
 import org.wwarn.surveyor.client.model.DataSourceProvider;
 import org.wwarn.surveyor.client.model.DatasourceConfig;
 
+import java.util.Date;
+
 public class DataProviderTestUtility {
 
     public static final String FIELD_PUBLICATION_YEAR = "PY";
 
     public DataProviderTestUtility() {
     }
+
+    public static final Date DATE_START_2001 = DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("01/01/2001");
+    public static final Date DATE_END_2003 = DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("31/12/2003");
 
     public String[] getSelectorList() {
         return new String[]{"PUB", "PTN", "QI", "TTL"};

--- a/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestDefaultLocalJSONDataProvider.java
+++ b/SurveyorCore/src/test/java/org/wwarn/surveyor/client/core/GwtTestDefaultLocalJSONDataProvider.java
@@ -474,7 +474,9 @@ public class GwtTestDefaultLocalJSONDataProvider extends VisualizationTest {
             @Override
             public void run() {
                 FilterQuery filterQuery = new FilterQuery();
-                filterQuery.addRangeFilter("SD", parseDateFromYearOnly("2001"), parseDateFromYearOnly("2002"));
+                //DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("01/01/2001")
+                //DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("31/12/2003")
+                filterQuery.addRangeFilter("SD", DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("01/01/2001"), DataType.ParseUtil.parseDateInEnglishDayMonthYearFormat("31/12/2003"));
                 try {
                     dataProvider.query(filterQuery, new AsyncCallbackWithTimeout<QueryResult>() {
                         @Override


### PR DESCRIPTION
…ssue by ensuring start year and end year is either implicit in test cases.

Or if only year component is given, start and end years are calculated as 01/01+startYear and 31/12+endYear explicitly, to ensure maximum range for inclusion.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/worldwideantimalarialresistancenetwork/wwarn-maps-surveyor/33)

<!-- Reviewable:end -->
