### PR TITLE
Increase wait time on GWT localforage tests by a magnitude from 10 seconds

### DIFF
--- a/gwt-localforage/src/test/java/org/wwarn/localforage/client/GwtTestLocalForage.java
+++ b/gwt-localforage/src/test/java/org/wwarn/localforage/client/GwtTestLocalForage.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
  */
 public class GwtTestLocalForage extends GWTTestCase {
 
-    public static final int TIMEOUT_MILLIS = 10000;
+    public static final int TIMEOUT_MILLIS = 100000; // wait for 100 seconds
 
     /**
      * Must refer to a valid module that sources this class.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/worldwideantimalarialresistancenetwork/wwarn-maps-surveyor/80)
<!-- Reviewable:end -->
