### PR TITLE
Disable offlinestorage in safari, due to SEVERE: UncaughtExceptionHandler

### DIFF
--- a/SurveyorCore/src/main/java/org/wwarn/surveyor/client/util/OfflineStorageUtil.java
+++ b/SurveyorCore/src/main/java/org/wwarn/surveyor/client/util/OfflineStorageUtil.java
@@ -52,6 +52,9 @@ public class OfflineStorageUtil<T> {
     private SerializationUtil serializationUtil = new SerializationUtil();
 
     public static native boolean isRecentBrowser()/*-{
+        // safari fails to deserialise data from local storage
+        if ( /^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {return false;}
+
         // ios version 7 seems to use a buggy or slow localStorage implementation works fine in 6, 5.1, 8
         if (/iP(hone|od|ad)/.test($wnd.navigator.platform)) {
             // supports iOS 2.0 and later: <http://bit.ly/TJjs1V>


### PR DESCRIPTION
com.google.gwt.core.client.JavaScriptException: (RangeError) : Maximum call stack size exceeded.
	at Unknown.nib(ClientSerializationStreamReader.java:35)
	at Unknown.cvb(StorageRPCSerializerImpl.java:71)
	at Unknown.Ipc(SerializationUtil.java:68)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/worldwideantimalarialresistancenetwork/wwarn-maps-surveyor/93)
<!-- Reviewable:end -->
